### PR TITLE
BoxShadow clipping

### DIFF
--- a/src/styles/_Projects.scss
+++ b/src/styles/_Projects.scss
@@ -9,7 +9,8 @@
   }
 
   .project {
-    overflow: hidden;
+    // el overflow debería ser visible para que no se corte el boxshadow que usas como bloom
+    overflow: visible;
     position: relative;
     width: 100%;
     height: 80vh;


### PR DESCRIPTION
así evitas que se corte el bloom que usas detrás de cada proyecto